### PR TITLE
Fix photo link on speakers.json

### DIFF
--- a/speakers.json
+++ b/speakers.json
@@ -171,7 +171,7 @@
         "Jetpack Compose"
       ],
       "bio": "10 yaşından beri yazılım geliştirmenin içerisinde yer alan öğrenci. Geleceğin Android GDE'si.",
-      "image": "https://ibb.co/vzMXnF8",
+      "image": "https://i.ibb.co/ZTb2DjC/IMG-4465.jpg",
       "email": "sarpremziaksu@gmail.com",
       "linkedin": "linkedin.com/in/sarpremziaksu",
       "twitter": "@sarpremziaksu ",


### PR DESCRIPTION
Should've put the raw image link at the beginning, needs to be checked for complications.